### PR TITLE
Updated badges on readme and linted code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem "omniauth-rails_csrf_protection"
 # gem "image_processing", "~> 1.2"
 
 # Use for New Relic APM
-gem 'newrelic_rpm'
+gem "newrelic_rpm"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
 # Berkeley ReEntry Student Program
 
-[![Bluejay Dashboard](https://img.shields.io/badge/Bluejay-Dashboard_04-blue.svg)](http://dashboard.bluejay.governify.io/dashboard/script/dashboardLoader.js?dashboardURL=https://reporter.bluejay.governify.io/api/v4/dashboards/tpa-CS169L-23-GH-cs169_berkeley-reentry-student-program/main)
-
-![build](https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/main.yml/badge.svg)
-
-<a href="https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/rubocop.yml/badge.svg"><img src="https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/rubocop.yml"/></a>
-
-<a href="https://codeclimate.com/github/cs169/berkeley-reentry-student-program/test_coverage"><img src="https://api.codeclimate.com/v1/badges/c34db83045f2d3756e29/test_coverage" /></a>
-
-<a href="https://codeclimate.com/github/cs169/berkeley-reentry-student-program/maintainability"><img src="https://api.codeclimate.com/v1/badges/c34db83045f2d3756e29/maintainability" /></a>
-
-<a href="https://www.pivotaltracker.com/n/projects/2553425"><img src="https://user-images.githubusercontent.com/67244883/154180887-f803124e-0156-4322-899d-ba475139d60d.png" /></a>
+[![build](https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/main.yml/badge.svg)](https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/main.yml)
+[![rubocop](https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/rubocop.yml/badge.svg)](https://github.com/cs169/berkeley-reentry-student-program/actions/workflows/rubocop.yml)
+[![test coverage](https://api.codeclimate.com/v1/badges/c34db83045f2d3756e29/test_coverage)](https://codeclimate.com/github/cs169/berkeley-reentry-student-program/test_coverage)
+[![maintainability](https://api.codeclimate.com/v1/badges/c34db83045f2d3756e29/maintainability)](https://codeclimate.com/github/cs169/berkeley-reentry-student-program/maintainability)
+[![pivotal tracker](https://user-images.githubusercontent.com/67244883/154180887-f803124e-0156-4322-899d-ba475139d60d.png)](https://www.pivotaltracker.com/n/projects/2553425)
 
 ## Description
 The Berkeley ReEntry Student Program is an application developed by UC Berkeley's CS169L students for the ReEntry Program at UC Berkeley. The application provides an easy-to-use interface for ReEntry students to sign-up for and use resources provided by UC Berkeley's ReEntry program.


### PR DESCRIPTION
Deleted BlueJay badge and fixed Rubocop badge. Updated badge format to match BJC-Teacher-Tracker README.md badge format.

<img width="1315" alt="Screen Shot 2025-03-12 at 10 32 40 PM" src="https://github.com/user-attachments/assets/3831019d-e16b-4834-98ca-3926ee0af445" />

