### PR TITLE
For Event Management Page: added delete functionality and export functionality

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -6,6 +6,7 @@ class Admin::EventsController < ApplicationController
 
   def index
     @events = Event.all
+    render "admin/events/index"
   end
 
   def new
@@ -47,6 +48,13 @@ class Admin::EventsController < ApplicationController
       redirect_to admin_events_path, flash: { success: "Event deleted successfully." }
     else
       redirect_to admin_events_path, flash: { error: "Failed to delete event." }
+    end
+  end
+
+  def export_events
+    @events = Event.all
+    respond_to do |format|
+      format.csv { send_data Event.to_csv, filename: "events-#{Date.today}.csv" }
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -17,4 +17,12 @@ class Event < ApplicationRecord
   def formatted_date
     date.strftime("%A, %B %d, %Y")
   end
+
+  def self.to_csv
+    require "csv"
+    CSV.generate(headers: true) do |csv|
+      csv << column_names
+      all.each { |event| csv << event.attributes.values_at(*column_names) }
+    end
+  end
 end

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -8,7 +8,11 @@
       <%= render "shared/flash_messages" %>
     </div>
     <h1 class="display-5 fw-bold" align="center" style="color: #003262">Manage Events</h1>
-    <br>
+
+    <div class="mb-3">
+      <%= link_to "Export", export_admin_events_path(format: :csv), class: "btn btn-secondary" %>
+    </div>
+
     <div class="table-responsive">
       <table id="eventsTable" class="display" style="width:100%">
         <thead>
@@ -31,7 +35,7 @@
               <td><%= event.location %></td>
               <td>
                 <%= link_to "Edit", edit_admin_event_path(event), class: 'btn btn-primary btn-sm' %>
-                <%= link_to "Delete", admin_event_path(event), method: :delete, data: { confirm: 'Are you sure you want to delete this event?' }, class: 'btn btn-danger btn-sm' %>
+                <%= button_to "Delete", admin_event_path(event), method: :delete, data: { confirm: 'Are you sure you want to delete this event?' }, class: 'btn btn-danger btn-sm' %>
               </td>
             </tr>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,11 @@ Rails.application.routes.draw do
 
   # event routes
   namespace :admin do
-    resources :events
+    resources :events do
+      collection do
+        get :export_events, defaults: { format: :csv }, as: :export
+      end
+    end
   end
 
   # advisor routes

--- a/features/admin_event_management.feature
+++ b/features/admin_event_management.feature
@@ -6,7 +6,4 @@ Feature: Admin Event Management
   Background:
     Given I logged in as a "Admin"
     And I am on the admins page
-
-  Scenario: Viewing the list of events
-    When I visit the admin_events page
     

--- a/features/admin_event_management.feature
+++ b/features/admin_event_management.feature
@@ -1,0 +1,12 @@
+Feature: Admin Event Management
+  As a logged-in admin
+  I want to be able to add, edit, and delete events
+  So that I can directly manipulate what events students see
+
+  Background:
+    Given I logged in as a "Admin"
+    And I am on the admins page
+
+  Scenario: Viewing the list of events
+    When I visit the admin_events page
+    


### PR DESCRIPTION
This PR adds the ability for admins to delete selected events as well as export events to a CSV file.

- Changed element tag for delete button from link_to to button_to which enabled delete button to finally work
- Added to_csv method to the Event model for exporting events to CSV.
- Created a route and controller action for exporting events in the admin panel
- Added a button to the admin events index page for triggering the export.
- Added a cucumber feature file to test event admin features, but haven't really started writing any tests yet...

Related Issues:
Closes #65 - Implement Admin Event Management with Forms

Future Work:
- write cucumber and rspec tests to cover these new features
- add active fields to event to toggle visibility on student view
- add actiontext/support flyer uploads
- etc.
